### PR TITLE
Add invalid registration ids to response

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ iex> GCM.push("api_key", ["registration_id1", "registration_id2"], %{notificatio
    canonical_ids: [], failure: 0,
    headers: [{"Content-Type", "application/json; charset=UTF-8"},
     {"Vary", "Accept-Encoding"}, {"Transfer-Encoding", "chunked"}],
-   not_registered_ids: [], status_code: 200, success: 2}}
+   invalid_registration_ids: [], not_registered_ids: [], status_code: 200, success: 2}}
 ```
 
 A successful push may have a list of `canonical_ids` which means that you **should** update your registration id to the `new` one.
@@ -43,18 +43,23 @@ iex> GCM.push(api_key, ["registration_id1", "registration_id2"])
    canonical_ids: [%{ old: "registration_id1", new: "new_registration_id1"}], failure: 0,
    headers: [{"Content-Type", "application/json; charset=UTF-8"},
     {"Vary", "Accept-Encoding"}, {"Transfer-Encoding", "chunked"}],
-   not_registered_ids: ["registration_id1"], status_code: 200, success: 2}}
+   invalid_registration_ids: [],
+   not_registered_ids: [], status_code: 200, success: 2}}
 ```
 
-A partial successful push may have `not_registered_ids`. According to GCM "An existing registration token may cease to be valid in a number of scenarios..."
+A partial successful push may have `not_registered_ids` and/or `invalid_registration_ids`.
+A "not registered id" is a registration id that was valid. According to GCM: "An existing registration token may cease to be valid in a number of scenarios..."
+
+An invalid registration is just wrong data.
 
 ```
-iex> GCM.push(api_key, ["registration_id1", "registration_id2"])
+iex> GCM.push(api_key, ["registration_id1", "registration_id2", "registration_id3"])
 {:ok,
  %{body: "...",
-   canonical_ids: [], failure: 1,
+   canonical_ids: [], failure: 2,
    headers: [{"Content-Type", "application/json; charset=UTF-8"},
     {"Vary", "Accept-Encoding"}, {"Transfer-Encoding", "chunked"}],
+   invalid_registration_ids: ["registration_id2"],
    not_registered_ids: ["registration_id1"], status_code: 200, success: 1}}
 ```
 

--- a/test/gcm_test.exs
+++ b/test/gcm_test.exs
@@ -29,6 +29,7 @@ defmodule GCMTest do
     assert push("api_key", registration_ids, options) ==
       { :ok, %{ canonical_ids: [],
                 not_registered_ids: [],
+                invalid_registration_ids: [],
                 success: 2,
                 failure: 0,
                 status_code: 200,
@@ -60,6 +61,39 @@ defmodule GCMTest do
     assert push("api_key", registration_ids, options) ==
       { :ok, %{ canonical_ids: [],
                 not_registered_ids: ["reg1"],
+                invalid_registration_ids: [],
+                success: 0,
+                failure: 1,
+                status_code: 200,
+                body: original_resp_body,
+                headers: headers } }
+
+    assert validate [Poison, HTTPoison]
+  end
+
+  test "push notification to GCM with InvalidRegistration" do
+    registration_ids = ["reg1"]
+    options = %{ data: %{ alert: "Push!" } }
+    req_body = "req_body"
+    resp_body = %{ "canonical_ids" => 0,
+                   "failure" => 1,
+                   "success" => 0,
+                   "results" => [%{ "error" => "InvalidRegistration" }] }
+    original_resp_body = "original"
+    headers = []
+
+    http_response = %HTTPoison.Response{status_code: 200,
+                                        body: original_resp_body,
+                                        headers: headers}
+
+    expect(Poison, :encode!, [%{ registration_ids: registration_ids, data: %{ alert: "Push!" } }], req_body)
+    expect(Poison, :decode!, [original_resp_body], resp_body)
+    expect(HTTPoison, :post, ["https://android.googleapis.com/gcm/send", req_body, [{"Authorization", "key=api_key"}, {"Content-Type", "application/json"}, {"Accept", "application/json"}]], { :ok, http_response })
+
+    assert push("api_key", registration_ids, options) ==
+      { :ok, %{ canonical_ids: [],
+                not_registered_ids: [],
+                invalid_registration_ids: ["reg1"],
                 success: 0,
                 failure: 1,
                 status_code: 200,
@@ -91,6 +125,7 @@ defmodule GCMTest do
     assert push("api_key", registration_ids, options) ==
       { :ok, %{ canonical_ids: [%{ old: "reg1", new: "newreg1" }],
                 not_registered_ids: [],
+                invalid_registration_ids: [],
                 success: 1,
                 failure: 0,
                 status_code: 200,


### PR DESCRIPTION
This PR adds the `invalid_registration_ids` to the map returned when GCM replies with 200. 

It also refactors the way the response is built to use `update_in` instead of a tuple of multiple lists as it does not scale if we want to support more possible errors/responses
